### PR TITLE
Support memory fields of sysstat 10.1.2

### DIFF
--- a/kSar/src/Linux.xml
+++ b/kSar/src/Linux.xml
@@ -224,6 +224,10 @@
                 <headerstr>CPU %usr %nice %sys %iowait %steal %irq %soft %guest %gnice %idle</headerstr>
                 <graphname>CPU</graphname>
             </Stat>
+            <Stat name="kmem5">
+                <headerstr>kbmemfree kbmemused %memused kbbuffers kbcached kbcommit %commit kbactive kbinact kbdirty</headerstr>
+                <graphname>KMEM2</graphname>
+            </Stat>
 
             <!-- GRAPHS -->
             <Graph name="PROC" Title="Proc" type="unique">
@@ -404,6 +408,15 @@
                 -->
                 <Plot Title="Idle" size="1">
                     <cols>%idle</cols>
+                </Plot>
+            </Graph>
+            <Graph name="KMEM2" Title="KMem" type="unique">
+                <Plot Title="KMem">
+                    <cols>kbmemfree kbmemused kbbuffers kbcached kbcommit kbactive kbinact kbdirty</cols>
+                    <format base="1024" factor="1024"></format>
+                </Plot>
+                <Plot Title="%">
+                    <cols>%memused %commit</cols>
                 </Plot>
             </Graph>
         </OSType>


### PR DESCRIPTION
sysstat 10.1.2 has the following fields for memory utilization statistics (`sar -r ALL`):
> kbmemfree kbmemused %memused kbbuffers kbcached kbcommit %commit kbactive kbinact kbdirty