### PR TITLE
Natural sort in tree view

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,4 +30,5 @@ dependencies {
     }
     compile 'com.jcraft:jsch:0.1.42'
     compile 'jfree:jfreechart:1.0.13'
+    testCompile 'junit:junit:4.12'
 }

--- a/src/main/java/net/atomique/ksar/UI/SortedTreeNode.java
+++ b/src/main/java/net/atomique/ksar/UI/SortedTreeNode.java
@@ -6,6 +6,7 @@
 package net.atomique.ksar.UI;
 
 import java.util.Collections;
+import java.util.Comparator;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.MutableTreeNode;
 
@@ -17,6 +18,7 @@ public class SortedTreeNode extends DefaultMutableTreeNode implements Comparable
 
     public static final long serialVersionUID = 15071L;
 
+    private static final Comparator<String> comparator = new SimpleNaturalComparator();
 
     public SortedTreeNode(String name) {
         super(name);
@@ -64,8 +66,31 @@ public class SortedTreeNode extends DefaultMutableTreeNode implements Comparable
         Collections.sort(this.children);
     }
     public int compareTo(final Object o) {
-        return this.toString().compareToIgnoreCase(o.toString());
+        return comparator.compare(this.toString(), o.toString());
     }
 
     private int leaf_num=0;
+
+    public static class SimpleNaturalComparator implements Comparator<String> {
+        @Override
+        public int compare(String s1, String s2) {
+            boolean isInt = true;
+
+            int i1 = 0;
+            try {
+                i1 = Integer.parseInt(s1);
+            } catch (NumberFormatException e) {
+                isInt = false;
+            }
+
+            int i2 = 0;
+            try {
+                i2 = Integer.parseInt(s2);
+            } catch (NumberFormatException e) {
+                isInt = false;
+            }
+
+            return isInt ? Integer.compare(i1, i2) : s1.compareToIgnoreCase(s2);
+        }
+    }
 }

--- a/src/test/java/net/atomique/ksar/UI/SimpleNaturalComparatorTest.java
+++ b/src/test/java/net/atomique/ksar/UI/SimpleNaturalComparatorTest.java
@@ -1,0 +1,16 @@
+package net.atomique.ksar.UI;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class SimpleNaturalComparatorTest {
+    @Test
+    public void testCompareNumbers() {
+        SortedTreeNode.SimpleNaturalComparator comparator = new SortedTreeNode.SimpleNaturalComparator();
+
+        assertTrue(comparator.compare("10", "2") > 0);
+        assertTrue(comparator.compare("a10", "a2") < 0);
+        assertTrue(comparator.compare("a", "1") > 0);
+    }
+}


### PR DESCRIPTION
This patch sorts items in the tree view by "natural order".

See #6 for the tree view.
With this patch, sub-items under CPU are ordered like 0, 1, 2, 3, ..., 9, 10, 11, ..., all.