### PR TITLE
Generate version file in build process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,3 +32,12 @@ dependencies {
     compile 'jfree:jfreechart:1.0.13'
     testCompile 'junit:junit:4.12'
 }
+
+task writeVersion << {
+    def s = version.find(/^\d.\d.\d/)
+    if (s == null) {
+        throw new InvalidUserDataException('Invalid version format')
+    }
+    new File("src/main/resources/kSar.version").text = s
+}
+classes.dependsOn(writeVersion)


### PR DESCRIPTION
Fixes #22, only version property in build.gradle needs to be maintained.