### PR TITLE
Network interface chart definition - sysstat <8.0 (e.g. RHEL 5.5)

### DIFF
--- a/src/main/resources/Linux.xml
+++ b/src/main/resources/Linux.xml
@@ -279,8 +279,9 @@
                 <Plot Title="packet">
                     <cols>rxpck/s txpck/s</cols>
                 </Plot>
-                <Plot Title="bytes">
+                <Plot Title="bandwidth">
                     <cols>rxbyt/s txbyt/s</cols>
+                    <format base="1024" factor="1" />
                 </Plot>
                 <Plot Title="compressed/cast">
                     <cols>rxcmp/s txcmp/s rxmcst/s</cols>


### PR DESCRIPTION
- change plot title: bytes --> bandwidth
- define base/factor to get units in KB/MB/GB