### PR TITLE
Adding autodetect option to linux timeformat dropdown list

### DIFF
--- a/src/main/java/net/atomique/ksar/AllParser.java
+++ b/src/main/java/net/atomique/ksar/AllParser.java
@@ -14,12 +14,26 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.TreeSet;
 
 public abstract class AllParser {
 
   private static final Logger log = LoggerFactory.getLogger(AllParser.class);
-
+  
+  private static final Map<String, String> DATE_FORMAT_REGEXPS = new HashMap<String, String>() {{
+      put("^\\d{8}$", "yyyyMMdd");
+      put("^\\d{1,2}-\\d{1,2}-\\d{4}$", "dd-MM-yyyy");
+      put("^\\d{4}-\\d{1,2}-\\d{1,2}$", "yyyy-MM-dd");
+      put("^\\d{1,2}/\\d{1,2}/\\d{4}$", "MM/dd/yyyy");
+      put("^\\d{4}/\\d{1,2}/\\d{1,2}$", "yyyy/MM/dd");
+      put("^\\d{1,2}\\s[a-z]{3}\\s\\d{4}$", "dd MMM yyyy");
+      put("^\\d{1,2}\\s[a-z]{4,}\\s\\d{4}$", "dd MMMM yyyy");
+      put("^\\d{1,2}-\\d{1,2}-\\d{2}$", "dd-MM-yy");
+      put("^\\d{1,2}/\\d{1,2}/\\d{2}$", "MM/dd/yy");
+  }};
+  
   public AllParser() {
 
   }
@@ -65,8 +79,14 @@ public abstract class AllParser {
     }
 
     try {
-      DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateFormat);
-      currentDate = LocalDate.parse(s, formatter);
+    	DateTimeFormatter formatter;
+    	if(dateFormat.equals("Autodetect")){
+        	formatter = DateTimeFormatter.ofPattern(determineDateFormat(s));
+        	currentDate = LocalDate.parse(s, formatter);
+    	}else{
+	      formatter = DateTimeFormatter.ofPattern(dateFormat);
+	      currentDate = LocalDate.parse(s, formatter);
+	    	}
 
       parsedate = currentDate;
 
@@ -101,6 +121,15 @@ public abstract class AllParser {
 
   public String getCurrentStat() {
     return currentStat;
+  }
+  
+  public static String determineDateFormat(String dateString) {
+      for (String regexp : DATE_FORMAT_REGEXPS.keySet()) {
+          if (dateString.toLowerCase().matches(regexp)) {
+              return DATE_FORMAT_REGEXPS.get(regexp);
+          }
+      }
+      return null; // Unknown format.
   }
 
 

--- a/src/main/java/net/atomique/ksar/export/FileCSV.java
+++ b/src/main/java/net/atomique/ksar/export/FileCSV.java
@@ -20,6 +20,7 @@ import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Iterator;
 
 import javax.swing.JDialog;
@@ -67,7 +68,12 @@ public class FileCSV implements Runnable {
           tmpLDT.getDayOfMonth(),
           tmpLDT.getMonthValue(),
           tmpLDT.getYear());
-
+      
+      //add date to csv
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yy HH:mm:ss");
+      String text = tmpLDT.format(formatter);
+      tmpcsv.append(text+";");
+      
       export_treenode_data(mysar.graphtree, tmp);
       tmpcsv.append("\n");
     }

--- a/src/main/java/net/atomique/ksar/parser/Linux.java
+++ b/src/main/java/net/atomique/ksar/parser/Linux.java
@@ -51,20 +51,24 @@ public class Linux extends OSParser {
     if ("Always ask".equals(LinuxDateFormat)) {
       askDateFormat();
     }
-
-    // day and year format specifiers must be lower case, month upper case
-    String[] parts = LinuxDateFormat.split(" ", 3);
-
-    dateFormat = parts[0];
-    dateFormat = dateFormat.replaceAll("D{2}", "dd");
-    dateFormat = dateFormat.replaceAll("Y{2}", "yy");
-
-    //12hour
-    if (parts.length == 3 && parts[2].contains("AM|PM")) {
-      timeFormat = "hh:mm:ss a";
-      timeColumn = 2;
+    
+    if("Autodetect".equals(LinuxDateFormat)){
+    	timeColumn = 0;
+    	dateFormat = "Autodetect";
+    }else{
+	    // day and year format specifiers must be lower case, month upper case
+	    String[] parts = LinuxDateFormat.split(" ", 3);
+	
+	    dateFormat = parts[0];
+	    dateFormat = dateFormat.replaceAll("D{2}", "dd");
+	    dateFormat = dateFormat.replaceAll("Y{2}", "yy");
+	
+	    //12hour
+	    if (parts.length == 3 && parts[2].contains("AM|PM")) {
+	      timeFormat = "hh:mm:ss a";
+	      timeColumn = 2;
+	    }
     }
-
   }
 
   private void askDateFormat() {
@@ -96,6 +100,15 @@ public class Linux extends OSParser {
     }
 
     try {
+   	 if ( timeColumn == 0 ) {
+         if ((columns[0]+" "+columns[1]).matches("^\\d\\d:\\d\\d:\\d\\d [AP]M$")) {
+        	 timeFormat = "hh:mm:ss a";
+             timeColumn=2;
+         }else{
+        	 timeColumn=1;
+         }
+	 }
+    	
       if (timeColumn == 2) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern(timeFormat, Locale.US);
         parsetime = LocalTime.parse(columns[0] + " " + columns[1], formatter);

--- a/src/main/java/net/atomique/ksar/ui/LinuxDateFormat.java
+++ b/src/main/java/net/atomique/ksar/ui/LinuxDateFormat.java
@@ -32,6 +32,7 @@ public class LinuxDateFormat extends javax.swing.JDialog {
     LinuxFormatComboModel.addElement("MM/DD/YYYY 12:59:59 AM|PM");
     LinuxFormatComboModel.addElement("DD/MM/YYYY 12:59:59 AM|PM");
     LinuxFormatComboModel.addElement("YYYY-MM-DD 12:59:59 AM|PM");
+    LinuxFormatComboModel.addElement("Autodetect");
   }
 
   /**

--- a/src/main/java/net/atomique/ksar/ui/Preferences.java
+++ b/src/main/java/net/atomique/ksar/ui/Preferences.java
@@ -57,6 +57,7 @@ public class Preferences extends javax.swing.JDialog {
     LinuxFormatComboModel.addElement("MM/DD/YYYY 12:59:59 AM|PM");
     LinuxFormatComboModel.addElement("DD/MM/YYYY 12:59:59 AM|PM");
     LinuxFormatComboModel.addElement("YYYY-MM-DD 12:59:59 AM|PM");
+    LinuxFormatComboModel.addElement("Autodetect");
     jComboBox3.setSelectedItem(Config.getLinuxDateFormat());
   }
 


### PR DESCRIPTION
Adding option for trying autodetect datetime format. There can be unsovable issue with detecting MM/DD/yyyy and DD/MM/yyyy so Autodetect was just added to dropdown list along with other options.