### PR TITLE
Support adding earlier values after newer ones.

### DIFF
--- a/src/main/java/net/atomique/ksar/AllParser.java
+++ b/src/main/java/net/atomique/ksar/AllParser.java
@@ -55,12 +55,35 @@ public abstract class AllParser {
     return -1;
   }
 
-  public LocalDateTime get_startofgraph() {
-    return startofgraph;
+  /**
+   * Set {@link #startOfGraph} and {@link #endOfGraph} to the given value if none are available yet
+   * or update either of both, depending on if the given value is earlier/later than the formerly
+   * stored corresponding one.
+   * 
+   * @param nowStat
+   */
+  protected void setStartAndEndOfGraph(LocalDateTime nowStat) {
+    if (startOfGraph == null) {
+      startOfGraph = nowStat;
+    }
+    if (endOfGraph == null) {
+      endOfGraph = nowStat;
+    }
+
+    if (nowStat.compareTo(startOfGraph) < 0) {
+      startOfGraph = nowStat;
+    }
+    if (nowStat.compareTo(endOfGraph) > 0) {
+      endOfGraph = nowStat;
+    }
   }
 
-  public LocalDateTime get_endofgraph() {
-    return endofgraph;
+public LocalDateTime getStartOfGraph() {
+    return startOfGraph;
+  }
+
+  public LocalDateTime getEndOfGraph() {
+    return endOfGraph;
   }
 
   public String getParserName() {
@@ -137,8 +160,9 @@ public abstract class AllParser {
   protected String sarStartDate = null;
   protected String sarEndDate = null;
 
-  protected LocalDateTime startofgraph = null;
-  protected LocalDateTime endofgraph = null;
+  private LocalDateTime startOfGraph = null;
+  private LocalDateTime endOfGraph = null;
+
   protected TreeSet<LocalDateTime> DateSamples = new TreeSet<LocalDateTime>();
   protected int firstdatacolumn = 0;
 

--- a/src/main/java/net/atomique/ksar/AllParser.java
+++ b/src/main/java/net/atomique/ksar/AllParser.java
@@ -59,8 +59,8 @@ public abstract class AllParser {
    * Set {@link #startOfGraph} and {@link #endOfGraph} to the given value if none are available yet
    * or update either of both, depending on if the given value is earlier/later than the formerly
    * stored corresponding one.
-   * 
-   * @param nowStat
+   *
+   * @param nowStat Date/time of the currently parsed line.
    */
   protected void setStartAndEndOfGraph(LocalDateTime nowStat) {
     if (startOfGraph == null) {
@@ -78,7 +78,7 @@ public abstract class AllParser {
     }
   }
 
-public LocalDateTime getStartOfGraph() {
+  public LocalDateTime getStartOfGraph() {
     return startOfGraph;
   }
 

--- a/src/main/java/net/atomique/ksar/OSParser.java
+++ b/src/main/java/net/atomique/ksar/OSParser.java
@@ -146,12 +146,12 @@ public abstract class OSParser extends AllParser {
         DateTimeFormatter formatter =
             DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT); //.withLocale(test);
 
-        if (startofgraph != null) {
-          asFormattedDateTimeStart = startofgraph.format(formatter);
+        if (this.getStartOfGraph() != null) {
+          asFormattedDateTimeStart = this.getStartOfGraph().format(formatter);
         }
-        if (endofgraph != null) {
+        if (this.getEndOfGraph() != null) {
           //asFormattedDateTimeEnd = endofgraph.format(DateTimeFormatter.ISO_DATE_TIME);
-          asFormattedDateTimeEnd = endofgraph.format(formatter);
+          asFormattedDateTimeEnd = this.getEndOfGraph().format(formatter);
         }
 
       } catch (DateTimeException ex) {

--- a/src/main/java/net/atomique/ksar/export/FilePDF.java
+++ b/src/main/java/net/atomique/ksar/export/FilePDF.java
@@ -180,7 +180,7 @@ public class FilePDF extends PdfPageEventHelper implements Runnable {
 
   public int addchart(PdfWriter writer, Graph graph) {
     JFreeChart chart =
-        graph.getgraph(mysar.myparser.get_startofgraph(), mysar.myparser.get_endofgraph());
+        graph.getgraph(mysar.myparser.getStartOfGraph(), mysar.myparser.getEndOfGraph());
     PdfTemplate pdftpl = pdfcb.createTemplate(pagewidth, pageheight);
     Graphics2D g2d = new PdfGraphics2D(pdftpl, pagewidth, pageheight);
     Double r2d = new Rectangle2D.Double(0, 0, pagewidth, pageheight);

--- a/src/main/java/net/atomique/ksar/graph/Graph.java
+++ b/src/main/java/net/atomique/ksar/graph/Graph.java
@@ -279,7 +279,7 @@ public class Graph {
       final int width, final int height) {
     try {
       ChartUtils.saveChartAsPNG(new File(filename),
-          this.getgraph(mysar.myparser.get_startofgraph(), mysar.myparser.get_endofgraph()), width,
+          this.getgraph(mysar.myparser.getStartOfGraph(), mysar.myparser.getEndOfGraph()), width,
           height);
     } catch (IOException e) {
       log.error("Unable to write to : {}", filename);
@@ -292,7 +292,7 @@ public class Graph {
       final int width, final int height) {
     try {
       ChartUtils.saveChartAsJPEG(new File(filename),
-          this.getgraph(mysar.myparser.get_startofgraph(), mysar.myparser.get_endofgraph()), width,
+          this.getgraph(mysar.myparser.getStartOfGraph(), mysar.myparser.getEndOfGraph()), width,
           height);
     } catch (IOException e) {
       log.error("Unable to write to : {}", filename);
@@ -316,9 +316,9 @@ public class Graph {
     } else {
       //TODO - get rid of Second, convert from LocalDateTime directly to java.util.Date - How to deal with required timezone in that case?
       java.util.Date getStartofGraphStart =
-          convertLocalDateTimeToSecond(mysar.myparser.get_startofgraph()).getStart();
+          convertLocalDateTimeToSecond(mysar.myparser.getStartOfGraph()).getStart();
       java.util.Date GetEndofGraphEnd =
-          convertLocalDateTimeToSecond(mysar.myparser.get_endofgraph()).getEnd();
+          convertLocalDateTimeToSecond(mysar.myparser.getEndOfGraph()).getEnd();
 
       if (!axisofdate.getMinimumDate().equals(getStartofGraphStart)) {
         axisofdate.setMinimumDate(getStartofGraphStart);
@@ -370,15 +370,15 @@ public class Graph {
         chartpanel = new ChartPanel(getgraph(null, null));
       } else {
         chartpanel = new ChartPanel(
-            getgraph(mysar.myparser.get_startofgraph(), mysar.myparser.get_endofgraph()));
+            getgraph(mysar.myparser.getStartOfGraph(), mysar.myparser.getEndOfGraph()));
       }
     } else {
       if (!mysar.isParsing()) {
         //TODO - get rid of Second, convert from LocalDateTime directly to java.util.Date - How to deal with required timezone in that case?
         java.util.Date getStartofGraphStart =
-            convertLocalDateTimeToSecond(mysar.myparser.get_startofgraph()).getStart();
+            convertLocalDateTimeToSecond(mysar.myparser.getStartOfGraph()).getStart();
         java.util.Date GetEndofGraphEnd =
-            convertLocalDateTimeToSecond(mysar.myparser.get_endofgraph()).getEnd();
+            convertLocalDateTimeToSecond(mysar.myparser.getEndOfGraph()).getEnd();
 
         if (!axisofdate.getMinimumDate().equals(getStartofGraphStart)) {
           axisofdate.setMinimumDate(getStartofGraphStart);

--- a/src/main/java/net/atomique/ksar/parser/AIX.java
+++ b/src/main/java/net/atomique/ksar/parser/AIX.java
@@ -64,15 +64,7 @@ public class AIX extends OSParser {
       LocalDateTime nowStat;
       nowStat = LocalDateTime.of(parsedate, parsetime);
 
-      if (startofgraph == null) {
-        startofgraph = nowStat;
-      }
-      if (endofgraph == null) {
-        endofgraph = nowStat;
-      }
-      if (nowStat.compareTo(endofgraph) > 0) {
-        endofgraph = nowStat;
-      }
+      this.setStartAndEndOfGraph(nowStat);
       firstdatacolumn = 1;
     } catch (DateTimeParseException ex) {
       if (!"DEVICE".equals(currentStat) || "CPUS".equals(currentStat)) {

--- a/src/main/java/net/atomique/ksar/parser/HPUX.java
+++ b/src/main/java/net/atomique/ksar/parser/HPUX.java
@@ -66,15 +66,7 @@ public class HPUX extends OSParser {
       LocalDateTime nowStat;
       nowStat = LocalDateTime.of(parsedate, parsetime);
 
-      if (startofgraph == null) {
-        startofgraph = nowStat;
-      }
-      if (endofgraph == null) {
-        endofgraph = nowStat;
-      }
-      if (nowStat.compareTo(endofgraph) > 0) {
-        endofgraph = nowStat;
-      }
+      this.setStartAndEndOfGraph(nowStat);
       firstdatacolumn = 1;
     } catch (DateTimeParseException ex) {
       if (!"DEVICE".equals(currentStat) && !"CPU".equals(currentStat)) {

--- a/src/main/java/net/atomique/ksar/parser/Linux.java
+++ b/src/main/java/net/atomique/ksar/parser/Linux.java
@@ -126,17 +126,8 @@ public class Linux extends OSParser {
         throw new IllegalArgumentException("date/time is missing");
       }
 
-      if (startofgraph == null) {
-        startofgraph = nowStat;
-      }
-      if (endofgraph == null) {
-        endofgraph = nowStat;
-      }
-      if (nowStat.compareTo(endofgraph) > 0) {
-        endofgraph = nowStat;
-      }
+      this.setStartAndEndOfGraph(nowStat);
       firstdatacolumn = timeColumn;
-
     } catch (DateTimeParseException | IllegalArgumentException ex) {
       log.error("unable to parse time {}", columns[0], ex);
       return -1;

--- a/src/main/java/net/atomique/ksar/parser/SunOS.java
+++ b/src/main/java/net/atomique/ksar/parser/SunOS.java
@@ -80,15 +80,7 @@ public class SunOS extends OSParser {
       LocalDateTime nowStat;
       nowStat = LocalDateTime.of(parsedate, parsetime);
 
-      if (startofgraph == null) {
-        startofgraph = nowStat;
-      }
-      if (endofgraph == null) {
-        endofgraph = nowStat;
-      }
-      if (nowStat.compareTo(endofgraph) > 0) {
-        endofgraph = nowStat;
-      }
+      this.setStartAndEndOfGraph(nowStat);
       firstdatacolumn = 1;
     } catch (DateTimeParseException ex) {
       if (!"DEVICE".equals(currentStat)) {

--- a/src/test/java/net/atomique/ksar/parser/HpuxHeaderTest.java
+++ b/src/test/java/net/atomique/ksar/parser/HpuxHeaderTest.java
@@ -43,7 +43,7 @@ public class HpuxHeaderTest {
     kSar ksar = new kSar();
     sut.init(ksar, header);
     sut.parse(sarString, columns);
-    assertEquals(expectedDate, sut.get_startofgraph());
+    assertEquals(expectedDate, sut.getStartOfGraph());
   }
 
   @Parameters

--- a/src/test/java/net/atomique/ksar/parser/LinuxHeaderTest.java
+++ b/src/test/java/net/atomique/ksar/parser/LinuxHeaderTest.java
@@ -48,7 +48,7 @@ public class LinuxHeaderTest {
     kSar ksar = new kSar();
     sut.init(ksar, header);
     sut.parse(sarString, columns);
-    assertEquals(expectedDate, sut.get_startofgraph());
+    assertEquals(expectedDate, sut.getStartOfGraph());
   }
 
   @Parameters

--- a/src/test/java/net/atomique/ksar/parser/SolarisHeaderTest.java
+++ b/src/test/java/net/atomique/ksar/parser/SolarisHeaderTest.java
@@ -43,7 +43,7 @@ public class SolarisHeaderTest {
     kSar ksar = new kSar();
     sut.init(ksar, header);
     sut.parse(sarString, columns);
-    assertEquals(expectedDate, sut.get_startofgraph());
+    assertEquals(expectedDate, sut.getStartOfGraph());
   }
 
   @Parameters


### PR DESCRIPTION
Setting `startofgraph` and `endofgraph`was duplicated between all parsers, so I centralized it in base class `AllParsers` and additionally renamed a bit to to better fit Java naming styles. Afterwards I was easily able to add that newer timestamps not only change `endofgraph`, but `startofgraph` as well, so one is able to add older `sar` files to existing graphs. That didn't work before. Adding older data seems to have simply been ignored somewhere, OTOH `AllParser.setDate` handled storing an earlier timestamp AND a later one already. So the implementation of both values is now in line.