### PR TITLE
Travis build config validation - fix hidden deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-sudo: false
 language: java
+
+os:
+  - linux
 
 jdk:
   - openjdk8
@@ -20,18 +22,15 @@ cache:
   - $HOME/.gradle/caches
   - $HOME/.gradle/wrapper
 
-#Test stage - Matrix expansion
-install: skip # will be done by gradlew check anyway
-script: ./gradlew check
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - jdk: openjdk-ea
-
 # GitHub Deploy Stage
 jobs:
   include:
+    - stage: test
+      install: skip # will be done by gradlew check anyway
+      script: ./gradlew check
+    - stage: jdk-ea
+      fast_finish: true
+      jdk:  openjdk-ea
     - stage: Github Release
       jdk:  openjdk8
       before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,15 @@ cache:
   - $HOME/.gradle/caches
   - $HOME/.gradle/wrapper
 
-# GitHub Deploy Stage
 jobs:
+  fast_finish: true
+  allow_failures:
+    - jdk:  openjdk-ea
   include:
     - stage: test
       install: skip # will be done by gradlew check anyway
       script: ./gradlew check
-    - stage: jdk-ea
-      fast_finish: true
-      jdk:  openjdk-ea
+
     - stage: Github Release
       jdk:  openjdk8
       before_install:
@@ -46,11 +46,11 @@ jobs:
       deploy:
         provider: releases
         prerelease: true
-        api_key:
+        token:
           secure: iKXXqoxPMsoLGlhKMwRB7dVdU0ZvOjzRaxm73zjEsEgyErL7LJ6YG+3wJl24UW8zxgpvM5hW0DKUkWSLfVoHa/1l+Bsb8yREAKJTYldZs3pjhQxWM7OBMeKWjTA7WccYrx4ShHgbgUvl4IuHXNY91kcu1pC6lZukpDUvdX4Ii70=
         file_glob: true
         file: "build/libs/ksar-*all.jar"
-        skip_cleanup: true
+        cleanup: false
         on:
           tags: true
           repo: vlsi/ksar


### PR DESCRIPTION
root: both matrix and jobs given, matrix overwrites jobs
root: deprecated key sudo (The key `sudo` has no effect anymore.)
root: key matrix is an alias for jobs, using jobs
root: missing os, using the default linux

jobs.include: unknown key fast_finish (true)
jobs.include.deploy: key api_key is an alias for token, using token
jobs.include.deploy: deprecated key skip_cleanup (not supported in dpl v2, use cleanup)
