### PR TITLE
fix #203 - Linux Chart - "Block Device statistics" don't plot 'areq-sz' and 'aqu-sz'

### DIFF
--- a/src/main/resources/Config.xml
+++ b/src/main/resources/Config.xml
@@ -111,6 +111,12 @@
         <itemcolor name="avgqu-sz">
             <color>255,255,170</color>
         </itemcolor>
+        <itemcolor name="areq-sz">
+            <color>170,255,170</color>
+        </itemcolor>
+        <itemcolor name="aqu-sz">
+            <color>255,255,170</color>
+        </itemcolor>
         <itemcolor name="await">
             <color>255,170,255</color>
         </itemcolor>

--- a/src/main/resources/Linux.xml
+++ b/src/main/resources/Linux.xml
@@ -386,7 +386,7 @@
                     <format base="1024" factor="1024" />
                 </Plot>
                 <Plot Title="areq-sz [KiB] / aqu-sz">
-                    <cols>avgrq-sz avgqu-sz</cols>
+                    <cols>areq-sz aqu-sz</cols>
                 </Plot>
                 <Plot Title="Response [ms]">
                     <cols>await</cols>


### PR DESCRIPTION
use correct statistic names and also add defined colors