### PR TITLE
ci: add randomised build matrix

### DIFF
--- a/.github/workflows/matrix.mjs
+++ b/.github/workflows/matrix.mjs
@@ -1,0 +1,125 @@
+// The script generates a random subset of valid jdk, os, timezone, and locale axes.
+// You can preview the results by running "npm ci && node matrix.mjs" from this directory.
+// See https://github.com/vlsi/github-actions-random-matrix
+import { appendFileSync } from 'fs';
+import { EOL } from 'os';
+import { createGitHubMatrixBuilder } from '@vlsi/github-actions-random-matrix/github';
+const { matrix, random } = createGitHubMatrixBuilder();
+
+matrix.addAxis({
+  name: 'java_distribution',
+  values: [
+    'corretto',
+    'liberica',
+    'microsoft',
+    'temurin',
+    'zulu',
+  ]
+});
+
+matrix.addAxis({
+  name: 'java_version',
+  title: x => 'Java ' + x,
+  // Strings allow versions like 18-ea
+  values: [
+    '17',
+    '21',
+    '25',
+  ]
+});
+
+matrix.addAxis({
+  name: 'tz',
+  title: x => 'tz ' + x,
+  values: [
+    'America/New_York',
+    'Pacific/Chatham',
+    'UTC',
+  ]
+});
+
+matrix.addAxis({
+  name: 'os',
+  title: x => (x.value || x).replace('-latest', ''),
+  values: [
+    {value: 'ubuntu-latest', weight: 4},
+    {value: 'windows-latest', weight: 1},
+    {value: 'macos-latest', weight: 1},
+  ]
+});
+
+// Test cases when Object#hashCode produces the same results.
+// It allows capturing cases when the code uses hashCode as a unique identifier.
+matrix.addAxis({
+  name: 'hash',
+  values: [
+    {value: 'regular', title: '', weight: 10},
+    {value: 'same', title: 'same hashcode', weight: 1},
+  ]
+});
+
+matrix.addAxis({
+  name: 'locale',
+  title: x => x.language + '_' + x.country,
+  values: [
+    {language: 'de', country: 'DE'},
+    {language: 'fr', country: 'FR'},
+    {language: 'ru', country: 'RU'},
+    {language: 'tr', country: 'TR'},
+  ]
+});
+
+matrix.setNamePattern(['java_version', 'java_distribution', 'hash', 'os', 'tz', 'locale']);
+
+// Cover every JDK version at least once
+matrix.ensureAllAxisValuesCovered('java_version');
+// Keep at least one Linux and one Windows job (macOS behaves much like Linux here)
+matrix.generateRow({os: {value: 'ubuntu-latest'}});
+matrix.generateRow({os: {value: 'windows-latest'}});
+// Keep at least one "same hashcode" job
+matrix.generateRow({hash: {value: 'same'}});
+// Keep at least one Turkish-locale job, since tr_TR case folding breaks naive toLowerCase calls
+matrix.generateRow({locale: {language: 'tr'}});
+
+const include = matrix.generateRows(process.env.MATRIX_JOBS || 6);
+if (include.length === 0) {
+  throw new Error('Matrix list is empty');
+}
+include.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true}));
+include.forEach(v => {
+  v.os = v.os.value;
+  // Extra JVM arguments passed to the test workers only (not to the Gradle daemon),
+  // so locale and JIT-stress options do not disturb Gradle itself.
+  // Values are joined with " ::: " because a single argument may contain spaces.
+  let testJvmArgs = [];
+  // Gradle does not start in tr_TR, so the locale is applied to tests only.
+  // See https://github.com/gradle/gradle/issues/17361
+  testJvmArgs.push(`-Duser.country=${v.locale.country}`);
+  testJvmArgs.push(`-Duser.language=${v.locale.language}`);
+  if (v.hash.value === 'same') {
+    // "same hashcode" trips up javac, so it is applied to test execution only.
+    // See https://github.com/pgjdbc/pgjdbc/pull/2821#issuecomment-1436013284
+    testJvmArgs.push('-XX:+UnlockExperimentalVMOptions', '-XX:hashCode=2');
+  }
+  if (random() > 0.5) {
+    // The following options randomise instruction selection in the JIT compiler,
+    // so they might reveal missing synchronisation in the code under test.
+    v.name += ', stress JIT';
+    testJvmArgs.push('-XX:+UnlockDiagnosticVMOptions');
+    // Randomise instruction scheduling in GCM and LCM (share/opto/c2_globals.hpp)
+    testJvmArgs.push('-XX:+StressGCM', '-XX:+StressLCM');
+    // Randomise worklist traversal in IGVN (Java 16+) and CCP (Java 17+).
+    // The lowest tested version is 17, so both options always apply.
+    testJvmArgs.push('-XX:+StressIGVN', '-XX:+StressCCP');
+  }
+  v.testExtraJvmArgs = testJvmArgs.join(' ::: ');
+  delete v.hash;
+});
+
+console.log(include);
+let filePath = process.env['GITHUB_OUTPUT'] || '';
+if (filePath) {
+  appendFileSync(filePath, `matrix<<MATRIX_BODY${EOL}${JSON.stringify({include})}${EOL}MATRIX_BODY${EOL}`, {
+    encoding: 'utf8'
+  });
+}

--- a/.github/workflows/package-lock.json
+++ b/.github/workflows/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "workflows",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@vlsi/github-actions-random-matrix": "2.0.0"
+      }
+    },
+    "node_modules/@vlsi/github-actions-random-matrix": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vlsi/github-actions-random-matrix/-/github-actions-random-matrix-2.0.0.tgz",
+      "integrity": "sha512-8lEb4eadMBKs+Hnj9dCmcHtgHoWelT4RMXAQ/VcQ1r3vjR8P2hSMVGhkRXaXibCBf0lMttS934CGo2mlBMopPA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/.github/workflows/package.json
+++ b/.github/workflows/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@vlsi/github-actions-random-matrix": "2.0.0"
+  }
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,46 +4,82 @@
 name: Test
 
 on:
+  # Run on pushes to master only; pull_request covers everything else,
+  # so feature branches with an open PR are not built twice.
   push:
     branches:
-      - '*'
+      - master
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+    inputs:
+      matrix_rng_seed:
+        description: RNG seed for reproducing a previous matrix
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  # On master/release we keep every job so no build is cancelled; the sha names the group.
+  # On PR branches a new push cancels the in-progress run.
+  # More info: https://stackoverflow.com/a/68422069/253468
+  group: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/release') && format('ci-test-{0}', github.sha) || format('ci-test-{0}', github.ref) }}
+  cancel-in-progress: true
 
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version:
-          - 17
-          - 21
-          - 25
+  matrix_prep:
+    name: Matrix preparation
     runs-on: ubuntu-latest
-    name: 'Test (JDK ${{ matrix.java-version }})'
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    env:
+      MATRIX_JOBS: 6
+      GITHUB_PR_NUMBER: ${{ github.event.number }}
+      RNG_SEED: ${{ github.event.inputs.matrix_rng_seed }}
     steps:
       - uses: actions/checkout@v6
-      - name: 'Set up JDK ${{ matrix.java-version }}'
+      - id: set-matrix
+        shell: bash
+        run: |
+          npm ci --prefix .github/workflows
+          node .github/workflows/matrix.mjs
+
+  build:
+    needs: matrix_prep
+    name: '${{ matrix.name }}'
+    runs-on: ${{ matrix.os }}
+    env:
+      TZ: ${{ matrix.tz }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.matrix_prep.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: 'Set up JDK ${{ matrix.java_version }}, ${{ matrix.java_distribution }}'
         uses: actions/setup-java@v5
         with:
-          java-version: ${{ matrix.java-version }}
-          distribution: liberica
+          java-version: ${{ matrix.java_version }}
+          distribution: ${{ matrix.java_distribution }}
       - name: 'Run tests'
         uses: burrunan/gradle-cache-action@v3
         with:
-          job-id: jdk${{ matrix.java-version }}
+          job-id: jdk${{ matrix.java_version }}
           arguments: --scan --no-parallel --no-daemon build
+          properties: |
+            testExtraJvmArgs=${{ matrix.testExtraJvmArgs }}
 
-  # Aggregate gate over the JDK matrix. Branch protection requires this single,
-  # stable check name so the required-checks list survives matrix changes.
+  # Aggregate gate over the matrix. Branch protection requires this single, stable
+  # check name, so the required-checks list survives changes to the matrix job names.
   tests:
     name: Tests
     if: always()
-    needs: build
+    needs: [matrix_prep, build]
     runs-on: ubuntu-latest
     steps:
-      - name: Fail if any matrix job did not succeed
-        if: needs.build.result != 'success'
+      - name: Fail if matrix preparation or any matrix job did not succeed
+        if: needs.matrix_prep.result != 'success' || needs.build.result != 'success'
         run: |
-          echo "Test matrix result: ${{ needs.build.result }}"
+          echo "matrix_prep: ${{ needs.matrix_prep.result }}"
+          echo "build: ${{ needs.build.result }}"
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ gradle-app.setting
 .idea/
 ksar_all.log
 out/
+
+# Node modules used by the CI matrix generator (.github/workflows)
+node_modules/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,14 @@ tasks.withType<JavaCompile>().configureEach {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    // The CI matrix (see .github/workflows/matrix.mjs) injects per-job JVM options such as
+    // the test locale and JIT-stress flags here, so they reach the test workers without
+    // affecting the Gradle daemon. Arguments are separated with " ::: " because a single
+    // value may contain spaces.
+    (project.findProperty("testExtraJvmArgs") as String?)
+        ?.split(" ::: ")
+        ?.filter { it.isNotBlank() }
+        ?.let { jvmArgs(it) }
 }
 
 val writeVersion by tasks.registering {

--- a/src/main/java/net/atomique/ksar/XMLConfig.java
+++ b/src/main/java/net/atomique/ksar/XMLConfig.java
@@ -40,7 +40,6 @@ public class XMLConfig extends DefaultHandler {
     }
 
     String dtdFile = publicId.substring(KSAR_DTD_PREFIX.length() - 1);
-    dtdFile = dtdFile.toLowerCase();
     InputStream inputStream = getClass().getResourceAsStream(dtdFile);
     if (inputStream == null) {
       throw new FileNotFoundException("File " + publicId + " is not found in kSar resources");

--- a/src/main/resources/AIX.xml
+++ b/src/main/resources/AIX.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/CONFIG.DTD" "config.dtd" >
+<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/config.dtd" "config.dtd" >
 <!--
     Description:
         Configure statistics and their corresponding graphs (plots+stacks)

--- a/src/main/resources/Config.xml
+++ b/src/main/resources/Config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/CONFIG.DTD" "config.dtd" >
+<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/config.dtd" "config.dtd" >
 <!--
     Description:
         Configure color of graphs

--- a/src/main/resources/Esar.xml
+++ b/src/main/resources/Esar.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/CONFIG.DTD" "config.dtd">
+<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/config.dtd" "config.dtd">
 <!--
     Description:
         Configure statistics and their corresponding graphs (plots+stacks)

--- a/src/main/resources/HPUX.xml
+++ b/src/main/resources/HPUX.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/CONFIG.DTD" "config.dtd">
+<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/config.dtd" "config.dtd">
 <!--
     Description:
         Configure statistics and their corresponding graphs (plots+stacks)

--- a/src/main/resources/Linux.xml
+++ b/src/main/resources/Linux.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/CONFIG.DTD" "config.dtd">
+<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/config.dtd" "config.dtd">
 <!--
     Description:
         Configure statistics and their corresponding graphs (plots+stacks)

--- a/src/main/resources/SunOS.xml
+++ b/src/main/resources/SunOS.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/CONFIG.DTD" "config.dtd">
+<!DOCTYPE ConfiG PUBLIC "-//NET/ATOMIQUE/KSAR/config.dtd" "config.dtd">
 <!--
     Description:
         Configure statistics and their corresponding graphs (plots+stacks)


### PR DESCRIPTION
## Why

The JDK test matrix was a fixed list (`17`, `21`, `25` on Linux only). It never exercised other JDK vendors, operating systems, timezones, or locales, so platform- and locale-specific bugs could land unnoticed. One such bug already existed: under `tr_TR`, `XMLConfig` could not resolve the config DTD.

## What

- Generate the matrix at runtime with `.github/workflows/matrix.mjs`, backed by the npm package `@vlsi/github-actions-random-matrix` (the same approach as pgjdbc). Each run picks a random subset across JDK vendor, JDK version, OS, timezone, `hashCode` mode, and locale.
- Seed the generator from the PR number (or `RNG_SEED` on manual dispatch), so a run is reproducible.
- Fix the `tr_TR` DTD-resolution bug: drop the default-locale `toLowerCase()` in `XMLConfig` and lowercase the public id in the `DOCTYPE` declarations.
- Pass per-job JVM options (locale, same `hashCode`, JIT stress) to the test workers through the `testExtraJvmArgs` Gradle property, leaving the Gradle daemon untouched (Gradle does not start in `tr_TR`).
- Keep the `Tests` job as a single, stable aggregate check, so branch protection and auto-merge survive the per-run job-name changes.

## How to verify

- `cd .github/workflows && npm ci && node matrix.mjs` prints a sample matrix.
- `./gradlew build -PtestExtraJvmArgs="-Duser.country=TR ::: -Duser.language=tr"` passes. Reverting the `XMLConfig` / `DOCTYPE` change makes `HpuxHeaderTest` fail with `FileNotFoundException: ... CONFIG.DTD`.
- CI: `matrix_prep` emits the matrix, `build` fans out across the random combinations, and `Tests` gates the overall result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)