### PR TITLE
Improve the command line interface

### DIFF
--- a/src/main/java/net/atomique/ksar/Main.java
+++ b/src/main/java/net/atomique/ksar/Main.java
@@ -27,7 +27,14 @@ public class Main {
   static ResourceBundle resource = ResourceBundle.getBundle("net/atomique/ksar/Language/Message");
 
   public static void usage() {
-    show_version();
+    log.info("Usage: ksar [OPTIONS]");
+    log.info("OPTIONS:");
+    log.info("  -input INPUTFILE    load INPUTFILE sa sar data");
+    log.info("  -debug              enable debug level output");
+    log.info("  -test               an alist for -debug option");
+    log.info("  -trace              enable trace level  output");
+    log.info("  -version            print the version information");
+    log.info("  -help               print this help message");
   }
 
   public static void show_version() {

--- a/src/main/java/net/atomique/ksar/Main.java
+++ b/src/main/java/net/atomique/ksar/Main.java
@@ -111,10 +111,13 @@ public class Main {
         if ("-input".equals(arg)) {
           if (i < args.length) {
             GlobalOptions.setCLfilename(args[i++]);
+            continue;
           } else {
             exit_error(resource.getString("INPUT_REQUIRE_ARG"));
           }
         }
+        exit_error(resource.getString("UNKNOWN_OPTION"), arg);
+      }
 
       }
     }
@@ -123,8 +126,8 @@ public class Main {
 
   }
 
-  public static void exit_error(final String message) {
-    log.error(message);
+  public static void exit_error(final String format, final String... args) {
+    log.error(format, (Object[]) args);
     System.exit(1);
 
   }

--- a/src/main/java/net/atomique/ksar/Main.java
+++ b/src/main/java/net/atomique/ksar/Main.java
@@ -91,7 +91,7 @@ public class Main {
         }
         if ("-help".equals(arg)) {
           usage();
-          continue;
+          System.exit(0);
         }
         if ("-test".equals(arg) || "-debug".equals(arg)) {
           root.setLevel(Level.DEBUG);

--- a/src/main/java/net/atomique/ksar/Main.java
+++ b/src/main/java/net/atomique/ksar/Main.java
@@ -18,6 +18,9 @@ import javax.swing.UnsupportedLookAndFeelException;
 public class Main {
 
   private static final Logger log = LoggerFactory.getLogger(Main.class);
+  static {
+    ((ch.qos.logback.classic.Logger)log).setLevel(Level.INFO);
+  }
 
   static Config config = null;
   static GlobalOptions globaloptions = null;

--- a/src/main/java/net/atomique/ksar/Main.java
+++ b/src/main/java/net/atomique/ksar/Main.java
@@ -10,6 +10,7 @@ import net.atomique.ksar.ui.Desktop;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
 import java.util.ResourceBundle;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
@@ -119,6 +120,9 @@ public class Main {
         exit_error(resource.getString("UNKNOWN_OPTION"), arg);
       }
 
+      if (i < args.length) {
+        exit_error(resource.getString("TOO_MANY_ARGUMENTS"),
+                   String.join(" ", Arrays.copyOfRange(args, i, args.length)));
       }
     }
 

--- a/src/main/java/net/atomique/ksar/Main.java
+++ b/src/main/java/net/atomique/ksar/Main.java
@@ -97,7 +97,7 @@ public class Main {
           show_version();
           System.exit(0);
         }
-        if ("-help".equals(arg)) {
+        if ("-help".equals(arg) || "--help".equals(arg) || "-h".equals(arg)) {
           usage();
           System.exit(0);
         }

--- a/src/main/resources/net/atomique/ksar/Language/Message.properties
+++ b/src/main/resources/net/atomique/ksar/Language/Message.properties
@@ -2,4 +2,5 @@
 # and open the template in the editor.
 
 INPUT_REQUIRE_ARG=-input requires a filename as the argument
+TOO_MANY_ARGUMENTS=too many arguments: {}
 UNKNOWN_OPTION=unknown option: {}

--- a/src/main/resources/net/atomique/ksar/Language/Message.properties
+++ b/src/main/resources/net/atomique/ksar/Language/Message.properties
@@ -2,3 +2,4 @@
 # and open the template in the editor.
 
 INPUT_REQUIRE_ARG=-input requires a filename as the argument
+UNKNOWN_OPTION=unknown option: {}


### PR DESCRIPTION
The `-input` option is handy. However, the `-help` option doesn't work, so there is no way to know about it.

I wonder whether we should use `Logger` to print the help message.
`System.out.print...` or `System.err.print...` looks better to me.
This is my first time writing a program in Java. I am not familiar with the conventions and culture of the language. 

Anyway, better than nothing.