### PR TITLE
ci(release-drafter): run only on push to master

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -30,6 +30,9 @@ template: |
 
   $CHANGES
 # See https://github.com/release-drafter/release-drafter#autolabeler
+# Kept as a reference only. The Release Drafter workflow runs on push and sets
+# disable-autolabeler: true, because labelling a PR needs pull-requests: write,
+# which read-only fork PR runs do not get. Label PRs by hand instead.
 autolabeler:
   - label: 'chore'
     files:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,16 +2,18 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
+    # Branches whose merges feed the draft release notes.
     branches:
       - master
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+  # No pull_request or pull_request_target trigger. The autolabeler is the only
+  # job that needs a PR event, and it is disabled below because labelling a PR
+  # requires pull-requests: write, which read-only fork PR runs do not get.
+  # pull_request_target would hand write-scoped secrets to forked PRs, so it is
+  # left out on purpose.
+
+# Default to read-only; the job that drafts the release opts into write below.
+permissions:
+  contents: read
 
 jobs:
   update_release_draft:
@@ -19,23 +21,21 @@ jobs:
     if: github.repository_owner == 'vlsi'
     name: Update Release Draft
     runs-on: ubuntu-latest
+    permissions:
+      # Write access is required to create and update the draft release.
+      contents: write
     env:
       # Publish pre-release files to a draft release
       PUBLISH_SNAPSHOT: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     steps:
-      # (Optional) GitHub Enterprise requires GHE_HOST variable set
-      #- name: Set GHE_HOST
-      #  run: |
-      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
-
-      # Drafts your next Release notes as Pull Requests are merged into "master"
+      # Drafts the next release notes as pull requests are merged into "master"
       - name: Update release body draft
         uses: release-drafter/release-drafter@v7
         id: prepare_release
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
+        with:
+          # The autolabeler needs PR events and pull-requests: write, neither of
+          # which this push-only workflow provides, so keep it off.
+          disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Checkout sources


### PR DESCRIPTION
## Why

Release Drafter ran on three events — `push`, `pull_request`, and `pull_request_target` — and failed on every PR:

- `pull_request` runs from forks get a read-only `GITHUB_TOKEN`. Release Drafter still tries to draft a release (needs `contents: write`) and run the autolabeler (needs `pull-requests: write`), so both 403.
- `pull_request_target` handed write-scoped secrets to forked PRs — a security hole that [pgjdbc warns against explicitly](https://github.com/pgjdbc/pgjdbc/blob/master/.github/workflows/release-drafter.yml).
- There was no `permissions` block at all.

The autolabeler was effectively dead anyway: recent PRs carry no labels.

## What

- Drop the `pull_request` and `pull_request_target` triggers; the workflow now runs only on `push` to `master`, so it can no longer fail in a PR.
- Add a read-only default `permissions` block (matching `test.yml`) with `contents: write` scoped to the job — exactly what drafting the release and attaching the snapshot jar need.
- Set `disable-autolabeler: true`. The autolabeler section stays in `.github/release-drafter.yml` as a reference, with a comment explaining why it is off.
- The snapshot build-and-attach logic is unchanged.

Mirrors the pgjdbc setup, adapted to ksar: kept the `v`-prefixed tag template (ksar tags as `v[0-9]+.[0-9]+.[0-9]+`) and version-tagged actions managed by Renovate, rather than copying pgjdbc's `REL` prefix and SHA pinning.

## How to verify

- YAML parses (`yaml.safe_load` on both files).
- No PR event triggers the workflow, so opening this PR does not start a Release Drafter run.
- On the next push to `master`, the draft release updates and the `ksar-*-all.jar` snapshot is attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)