### PR TITLE
ci(renovate): label deps, lint config, group by Maven groupId

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,6 +12,10 @@ categories:
       - 'bug'
   - title: '🧰 Maintenance'
     label: 'chore'
+  - title: '⬆️ Dependencies'
+    collapse-after: 8
+    labels:
+      - 'dependencies'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:

--- a/.github/workflows/renovate-config-lint.yml
+++ b/.github/workflows/renovate-config-lint.yml
@@ -1,0 +1,23 @@
+name: Validate Renovate Config
+
+on:
+  push:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yml
+  pull_request:
+    paths:
+      - renovate.json
+      - .github/workflows/renovate-config-lint.yml
+
+permissions:
+  contents: read
+
+jobs:
+  validate-renovate-config:
+    name: Validate renovate.json
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Validate renovate.json
+        run: docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -1,15 +1,25 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
   ],
   "schedule": ["every 3 weeks on Monday"],
   "automerge": true,
   "platformAutomerge": true,
+  "vulnerabilityAlerts": {
+    "description": "Security updates bypass the packageRules grouping below (Renovate resets their groupName), so apply the same groupId grouping to them here.",
+    "groupName": "{{{replace ':.*' '' depName}}}"
+  },
   "packageRules": [
     {
-      "matchPackagePrefixes": ["ch.qos.logback"],
-      "groupName": "ch.qos.logback"
+      "description": "Group every Maven update by its groupId. Add a more specific rule after this one to span several groupIds, pin a version, or disable a dependency.",
+      "matchDatasources": [
+        "maven"
+      ],
+      "groupName": "{{{replace ':.*' '' depName}}}"
     }
   ]
 }


### PR DESCRIPTION
## Why

Renovate PRs currently land uncategorised in the draft release notes, and the config has no automated validation. Security advisories also open one PR per artifact: a single advisory that bumps several artifacts of the same project produces several separate PRs, because Renovate resets the `groupName` for security updates.

## What

- **`dependencies` label.** Add `labels: ["dependencies"]` to `renovate.json` and a matching `⬆️ Dependencies` category (`collapse-after: 8`) in `release-drafter.yml`, so dependency updates land in their own collapsible section.
- **Config lint workflow.** Add `.github/workflows/renovate-config-lint.yml`, which runs `renovate-config-validator` on changes to `renovate.json` or the workflow itself. Mirrors [apache/jmeter#6704](https://github.com/apache/jmeter/pull/6704), adapted to this repo's CI conventions (version-tag actions, read-only permissions).
- **Group by Maven groupId.** Add a catch-all `packageRule` (`matchDatasources: ["maven"]`) that sets `groupName` to the dependency's groupId, and a `vulnerabilityAlerts` block with the same template so security updates group the same way. Drop the now-redundant `ch.qos.logback` rule, which the catch-all covers. Mirrors [apache/jmeter#6710](https://github.com/apache/jmeter/pull/6710).
- **Preset migration.** Migrate the deprecated `config:base` to `config:recommended`, clearing the warning the new lint workflow surfaces.

## How to verify

- `docker run --rm -v "$PWD":/work -w /work renovate/renovate:latest renovate-config-validator renovate.json` exits 0 with no warnings.
- The new workflow runs on this PR, since it touches both `renovate.json` and the workflow file.

## Note

Grouping is by exact groupId, so a project split across several groupIds forms one group per groupId. Where several groupIds should move together (or a dependency later adds a sub-groupId such as `ch.qos.logback.contrib`), add an explicit rule after the catch-all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)